### PR TITLE
Remove or replace unconventional repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -63,7 +63,7 @@ repositories {
 dependencies {
     // Things needed to compile the plugin
     implementation "org.spigotmc:spigot-api:$spigotVersion"
-    implementation "net.milkbowl.vault:VaultAPI:$vaultApiVersion"
+    implementation "com.github.MilkBowl:VaultAPI:$vaultApiVersion"
     implementation "com.sk89q.worldedit:worldedit-core:$worldEditCoreVersion"
     implementation "com.sk89q.worldguard:worldguard-bukkit:$worldGuardBukkitVersion"
     implementation "me.clip:placeholderapi:$placeholderApiVersion"

--- a/build.gradle
+++ b/build.gradle
@@ -54,12 +54,9 @@ project.ext.tokens = [
 // Extra repos for Bukkit/Spigot stuff
 repositories {
     mavenCentral()
-    maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
     maven { url 'https://hub.spigotmc.org/nexus/content/repositories/snapshots/' }
-    maven { url 'http://nexus.hc.to/content/repositories/pub_releases/' }
-    maven { url 'https://maven.sk89q.com/repo/' }
-    maven { url 'https://repo.mikeprimm.com' }
-    maven { url 'https://papermc.io/repo/repository/maven-public/' }
+    maven { url 'https://jitpack.io' }
+    maven { url 'https://maven.enginehub.org/repo/' }
     maven { url 'https://repo.extendedclip.com/content/repositories/placeholderapi/' }
 }
 


### PR DESCRIPTION
As of MilkBowl/VaultAPI#90, the main repository of the VaultAPI is jitpack and as according to the Worldguard documentation eniginehub is the correct repository. Sonatype is only really needed for  bungee, however it is already defined by [MavenCentral](https://mvnrepository.com/artifact/net.md-5/bungeecord-api/1.16-R0.4) so it will be obtained from there either way (since mavenCentral is defined above the sonatype repo) and I have no clue why papermc or mikeprimm's repositories are used.

I have tested that this compiles with a cleared gradle cache beforehand (and appearantly I didn't clear all caches and just a few, fun).