### PR TITLE
Try to fix minecarts being interactable

### DIFF
--- a/src/main/java/com/cjburkey/claimchunk/config/ClaimChunkWorldProfileHandler.java
+++ b/src/main/java/com/cjburkey/claimchunk/config/ClaimChunkWorldProfileHandler.java
@@ -213,6 +213,7 @@ public class ClaimChunkWorldProfileHandler {
         // Assign entity defaults
         claimedChunks.entityAccesses.put(EntityType.UNKNOWN, new EntityAccess(false, false, false));
         claimedChunks.entityAccessClassMapping.put("MONSTERS", new EntityAccess(true, true, false));
+        claimedChunks.entityAccessClassMapping.put("VEHICLES", new EntityAccess(true, false, false));
         unclaimedChunks.entityAccesses.put(EntityType.UNKNOWN, new EntityAccess(true, true, true));
 
         // Assign block defaults
@@ -276,9 +277,20 @@ public class ClaimChunkWorldProfileHandler {
                                                 entityType.getEntityClass()))
                 .forEach(animals::add);
 
+        // Add mine-carts
+        HashSet<EntityType> vehicles = new HashSet<>();
+        Arrays.stream(EntityType.values())
+                .filter(
+                        entityType ->
+                                entityType.getEntityClass() != null
+                                        && Minecart.class.isAssignableFrom(
+                                        entityType.getEntityClass()))
+                .forEach(vehicles::add);
+
         entityAccessMapping.put("MONSTERS", monsters);
         entityAccessMapping.put("HANGING_ENTITIES", hangingEntities);
         entityAccessMapping.put("ANIMALS", animals);
+        entityAccessMapping.put("VEHICLES", vehicles);
 
         return entityAccessMapping;
     }

--- a/src/main/java/com/cjburkey/claimchunk/event/WorldProfileEventHandler.java
+++ b/src/main/java/com/cjburkey/claimchunk/event/WorldProfileEventHandler.java
@@ -30,6 +30,7 @@ import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.hanging.HangingBreakEvent;
 import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.event.player.*;
+import org.bukkit.event.vehicle.VehicleEntityCollisionEvent;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -41,7 +42,7 @@ public record WorldProfileEventHandler(ClaimChunk claimChunk) implements Listene
 
     // -- EVENTS -- //
 
-    /** Event handler for when a player right clicks on an entity. */
+    /** Event handler for when a player right-clicks on an entity. */
     @EventHandler
     public void onEntityInteraction(PlayerInteractEntityEvent event) {
         if (event != null && !event.isCancelled()) {
@@ -84,6 +85,21 @@ public record WorldProfileEventHandler(ClaimChunk claimChunk) implements Listene
             // TODO: CHECK IF THE PROFILE SHOULD BLOCK GIVEN ENTITIES FROM SPAWNING
             //       I THINK WE MAY NEED A NEW PERMISSION FLAG ON ENTITY ACCESSES.
             // }
+        }
+    }
+
+    @EventHandler
+    public void onEntityPush(VehicleEntityCollisionEvent event) {
+        if (event != null && !event.isCancelled() && !event.isCollisionCancelled()) {
+            // If the entity pushing the cart is a player,
+            if (event.getEntity() instanceof Player player) {
+                // Then count this as an interaction event on this type
+                onEntityEvent(
+                        () -> event.setCancelled(true),
+                        player,
+                        event.getVehicle(),
+                        EntityAccess.EntityAccessType.INTERACT);
+            }
         }
     }
 


### PR DESCRIPTION
Add a VehicleEntityCollisionEvent listener to try to catch people pushing (hopper) minecarts out of claimed chunks to remove them from protection.