### PR TITLE
Single command claiming

### DIFF
--- a/src/main/java/com/cjburkey/claimchunk/ClaimChunkConfig.java
+++ b/src/main/java/com/cjburkey/claimchunk/ClaimChunkConfig.java
@@ -36,6 +36,7 @@ public class ClaimChunkConfig {
     /* Chunk Outlines */
 
     @Getter private String chunkOutlineParticle;
+    @Getter private String chunkFreeOutlineParticle;
     @Getter private int chunkOutlineDurationSeconds;
     @Getter private int chunkOutlineSpawnPerSec;
     @Getter private int chunkOutlineParticlesPerSpawn;
@@ -126,6 +127,7 @@ public class ClaimChunkConfig {
         maxScanRange = getInt("chunks", "maxScanRange");
 
         chunkOutlineParticle = getString("chunkOutline", "name");
+        chunkFreeOutlineParticle = getString("chunkOutline", "freeName");
         chunkOutlineDurationSeconds = getInt("chunkOutline", "durationSeconds");
         chunkOutlineSpawnPerSec = getInt("chunkOutline", "spawnsPerSecond");
         chunkOutlineParticlesPerSpawn = getInt("chunkOutline", "particlesPerSpawn");

--- a/src/main/java/com/cjburkey/claimchunk/i18n/V2JsonMessages.java
+++ b/src/main/java/com/cjburkey/claimchunk/i18n/V2JsonMessages.java
@@ -110,6 +110,9 @@ public final class V2JsonMessages {
     // Scan localization
     public String scanInputTooBig = "&6Scan area too large, max area is %%MAXAREA%%";
     public String claimsFound = "&6%%NEARBY%% chunks found within a %%RADIUS%% chunk radius";
+    public String claimNow = "Claim this chunk now!";
+    public String toClaimUse = "To claim this chunk use";
+    public String toClaimUseCommand = "command";
 
     // Help localization
     public String helpHeader = "&6--- [ &lClaimChunk Help&r&6 ] ---";

--- a/src/main/java/com/cjburkey/claimchunk/smartcommand/CCSubCommand.java
+++ b/src/main/java/com/cjburkey/claimchunk/smartcommand/CCSubCommand.java
@@ -6,6 +6,7 @@ import com.cjburkey.claimchunk.Utils;
 import de.goldmensch.commanddispatcher.Executor;
 import de.goldmensch.commanddispatcher.subcommand.SmartSubCommand;
 
+import net.md_5.bungee.api.chat.BaseComponent;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.TabCompleter;
@@ -106,6 +107,17 @@ public abstract class CCSubCommand extends SmartSubCommand implements TabComplet
     protected final void messageChat(
             @NotNull CommandSender sender, @NotNull String msg, @NotNull Object... arguments) {
         Utils.msg(sender, msg.formatted(arguments));
+    }
+
+    /**
+     * Sens a BaseComponent to a CommandSender.
+     *
+     * @param sender The message recipient.
+     * @param msg The message with formatting placeholders.
+     */
+    protected final void messageChatComponent(
+            @NotNull CommandSender sender, @NotNull BaseComponent msg) {
+        Utils.msg(sender, msg);
     }
 
     /**

--- a/src/main/java/com/cjburkey/claimchunk/smartcommand/ClaimChunkBaseCommand.java
+++ b/src/main/java/com/cjburkey/claimchunk/smartcommand/ClaimChunkBaseCommand.java
@@ -8,10 +8,12 @@ import com.cjburkey.claimchunk.smartcommand.sub.admin.AdminUnclaimAllCmd;
 import com.cjburkey.claimchunk.smartcommand.sub.admin.AdminUnclaimCmd;
 import com.cjburkey.claimchunk.smartcommand.sub.ply.*;
 
+import de.goldmensch.commanddispatcher.Commands;
 import de.goldmensch.commanddispatcher.Executor;
 import de.goldmensch.commanddispatcher.command.SmartCommand;
 import de.goldmensch.commanddispatcher.exceptions.CommandNotValidException;
 
+import de.goldmensch.commanddispatcher.subcommand.SmartSubCommand;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandSender;
 import org.jetbrains.annotations.NotNull;
@@ -85,6 +87,15 @@ public class ClaimChunkBaseCommand extends SmartCommand {
                 new CommandStr(new AdminUnclaimCmd(claimChunk), "admin", "unclaim"),
                 // `/chunk admin reload`
                 new CommandStr(new AdminReloadCmd(claimChunk), "admin", "reload"));
+    }
+
+    @Override
+    public boolean onCommand(@NotNull CommandSender sender, @NotNull Command bukkitCommand, @NotNull String label, @NotNull String[] args) {
+
+        if(args.length == 0) {
+            return new InfoCmd(claimChunk).onCommand(sender, bukkitCommand, label, args);
+        }
+        return super.onCommand(sender, bukkitCommand, label, args);
     }
 
     private void registerCmds(CommandStr... commands) {

--- a/src/main/java/com/cjburkey/claimchunk/smartcommand/sub/ply/InfoCmd.java
+++ b/src/main/java/com/cjburkey/claimchunk/smartcommand/sub/ply/InfoCmd.java
@@ -1,10 +1,18 @@
 package com.cjburkey.claimchunk.smartcommand.sub.ply;
 
 import com.cjburkey.claimchunk.ClaimChunk;
+import com.cjburkey.claimchunk.chunk.ChunkOutlineHandler;
+import com.cjburkey.claimchunk.chunk.ChunkPos;
 import com.cjburkey.claimchunk.smartcommand.CCSubCommand;
 
 import de.goldmensch.commanddispatcher.Executor;
 
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
+import net.md_5.bungee.api.chat.hover.content.Text;
+import org.bukkit.ChatColor;
+import org.bukkit.Particle;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +21,6 @@ import java.util.Optional;
 
 /** @since 0.0.23 */
 public class InfoCmd extends CCSubCommand {
-
     public InfoCmd(ClaimChunk claimChunk) {
         super(claimChunk, Executor.PLAYER, "info", true);
     }
@@ -38,6 +45,7 @@ public class InfoCmd extends CCSubCommand {
         var player = (Player) executor;
         var playerHandler = claimChunk.getPlayerHandler();
         var chunk = player.getLocation().getChunk();
+        var chunkPos = new ChunkPos(chunk);
         var owner = claimChunk.getChunkHandler().getOwner(chunk);
 
         var ownerName = ((owner == null) ? null : playerHandler.getUsername(owner));
@@ -64,6 +72,11 @@ public class InfoCmd extends CCSubCommand {
                                 .replace("%%X%%", "" + chunk.getX())
                                 .replace("%%Z%%", "" + chunk.getZ())
                                 .replace("%%WORLD%%", chunk.getWorld().getName())));
+
+        if(ownerName.equals(player.getName())) {
+            ownerName += " (you)"; //TODO: add to messages config
+        }
+
         messageChat(
                 player,
                 claimChunk.getConfigHandler().getInfoColor()
@@ -72,6 +85,51 @@ public class InfoCmd extends CCSubCommand {
                 player,
                 claimChunk.getConfigHandler().getInfoColor()
                         + claimChunk.getMessages().infoName.replace("%%NAME%%", ownerDisplay));
+        Particle particle;
+        particle = Particle.SMOKE_NORMAL;
+
+        if(owner == null) {
+            TextComponent cCommand = new TextComponent(ChatColor.YELLOW + "/chunk claim");
+            cCommand.setClickEvent(new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/chunk claim"));
+            cCommand.setHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, new Text(claimChunk.getMessages().claimNow)));
+
+            TextComponent message = new TextComponent(claimChunk.getConfigHandler().getInfoColor() + claimChunk.getMessages().toClaimUse + " ");
+            message.addExtra(cCommand);
+            message.addExtra(claimChunk.getConfigHandler().getInfoColor() + " " + claimChunk.getMessages().toClaimUseCommand);
+
+
+            messageChatComponent(
+                    player,
+                    message); //Todo: single message with placeholders for clickable command?
+
+            try {
+                particle = Particle.valueOf(claimChunk
+                        .getConfigHandler().getChunkFreeOutlineParticle());
+            } catch (Exception ex) {
+                particle = Particle.SMOKE_NORMAL;
+            }
+        }
+
+        ChunkOutlineHandler chunkOutlineHandler = //Todo: showChunkFor method with particle argument to avoid create separate ChunkOutlineHandler or create some decorator/proxy
+                new ChunkOutlineHandler(
+                        claimChunk,
+                        particle,
+                        20 / claimChunk
+                                .getConfigHandler().getChunkOutlineSpawnPerSec(),
+                        claimChunk
+                                .getConfigHandler().getChunkOutlineHeightRadius(),
+                        claimChunk
+                                .getConfigHandler().getChunkOutlineParticlesPerSpawn());
+
+        chunkOutlineHandler
+                .showChunkFor(
+                        chunkPos,
+                        player,
+                        claimChunk
+                                .getConfigHandler()
+                                .getChunkOutlineDurationSeconds(),
+                        ChunkOutlineHandler.OutlineSides.makeAll(true));
+
         return true;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -37,6 +37,7 @@ chunks:
 
 chunkOutline:
   name: 'SMOKE_LARGE'
+  freeName: 'VILLAGER_HAPPY'
   durationSeconds: 5
   spawnsPerSecond: 2
   particlesPerSpawn: 2


### PR DESCRIPTION
Related to #271 

add `/chunk` command with all info about current chunk, display borders and give simple one click possibility to claim it

![image](https://user-images.githubusercontent.com/1472664/197390796-986b47ce-3fec-4c40-8631-03e24eb5112f.png)

![image](https://user-images.githubusercontent.com/1472664/197390909-1d1385af-676e-4b93-979d-922e400591a3.png)


Unfortunately, I don't have much time to finish the code (to "production-ready" condition) =(
