### PR TITLE
PIN GH Actions to commit SHA

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,11 +48,11 @@ jobs:
           build-mode: autobuild
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 #v4.3.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@303c0aef88fc2fe5ff6d63d3b1596bfd83dfa1f9 #v3.30.4
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
@@ -78,6 +78,6 @@ jobs:
         exit 1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@303c0aef88fc2fe5ff6d63d3b1596bfd83dfa1f9 #v3.30.4
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -18,14 +18,14 @@ jobs:
         java: [21]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 #v4.3.0
     - name: Set up JDK ${{ matrix.java }}
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 #v4.7.1
       with:
         java-version: ${{ matrix.java }}
         distribution: 'adopt'
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4.3.0
       with:
         path: |
           ~/.gradle/caches
@@ -41,7 +41,7 @@ jobs:
       run: ./gradlew clean build --no-daemon
 
     - name: Upload artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4.6.2
       with:
         # Artifact name
         name: ClaimChunk


### PR DESCRIPTION
Pinning GitHub Actions for Enhanced Security

So you can then also think about activating this:
https://github.blog/changelog/2025-08-15-github-actions-policy-now-supports-blocking-and-sha-pinning-actions/

Dependabot can still update all dependencies, including those referenced by their SHA value
Maybe the existing PRs need to be recreated with `@dependabot recreate`